### PR TITLE
Move dreyfus config before [admins]

### DIFF
--- a/rel/overlay/etc/local.ini
+++ b/rel/overlay/etc/local.ini
@@ -98,6 +98,9 @@
 [update_notification]
 ;unique notifier name=/full/path/to/exe -with "cmd line arg"
 
+[dreyfus]
+name = {{clouseau_name}}
+
 ; To create an admin account uncomment the '[admins]' section below and add a
 ; line in the format 'username = password'. When you next start CouchDB, it
 ; will change the password to a hash (so that your passwords don't linger
@@ -106,6 +109,3 @@
 ; changing this.
 [admins]
 ;admin = mysecretpassword
-
-[dreyfus]
-name = {{clouseau_name}}


### PR DESCRIPTION
avoid conflicts when run couchDB with flags --admin=user:pass because this flag adds credentials at the end of the file in domains of [dreyfus] not [admins]
