### PR TITLE
calculate data_size correctly

### DIFF
--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -315,7 +315,10 @@ temp_view_to_ddoc({Props}) ->
 
 
 get_row_count(#mrview{btree=Bt}) ->
-    {ok, {Count, _Reds}} = couch_btree:full_reduce(Bt),
+    Count = case couch_btree:full_reduce(Bt) of
+        {ok, {Count0, _Reds, _}} -> Count0;
+        {ok, {Count0, _Reds}} -> Count0
+    end,
     {ok, Count}.
 
 
@@ -586,7 +589,6 @@ make_header(State) ->
         log_btree=LogBtree,
         views=Views
     } = State,
-
     #mrheader{
         seq=Seq,
         purge_seq=PurgeSeq,
@@ -763,26 +765,32 @@ changes_ekey_opts(_StartSeq, #mrargs{end_key=EKey,
     end.
 
 
+reduced_external_size(Tree) ->
+    case couch_btree:full_reduce(Tree) of
+        {ok, {_, _, Size}} -> Size;
+        % return null for versions of the reduce function without Size
+        {ok, {_, _}} -> null
+    end.
 
 
 calculate_external_size(Views) ->
     SumFun = fun(#mrview{btree=Bt, seq_btree=SBt, key_byseq_btree=KSBt}, Acc) ->
-        Size0 = sum_btree_sizes(Acc, couch_btree:size(Bt)),
+        Size0 = sum_btree_sizes(Acc, reduced_external_size(Bt)),
         Size1 = case SBt of
             nil -> Size0;
-            _ -> sum_btree_sizes(Size0, couch_btree:size(SBt))
+            _ -> sum_btree_sizes(Size0, reduced_external_size(SBt))
         end,
         case KSBt of
             nil -> Size1;
-            _ -> sum_btree_sizes(Size1, couch_btree:size(KSBt))
+            _ -> sum_btree_sizes(Size1, reduced_external_size(KSBt))
         end
     end,
     {ok, lists:foldl(SumFun, 0, Views)}.
 
 
-sum_btree_sizes(nil, _) ->
+sum_btree_sizes(null, _) ->
     null;
-sum_btree_sizes(_, nil) ->
+sum_btree_sizes(_, null) ->
     null;
 sum_btree_sizes(Size1, Size2) ->
     Size1 + Size2.
@@ -1015,22 +1023,32 @@ get_user_reds(Reduction) ->
     element(2, Reduction).
 
 
+get_external_reds(Reduction) when tuple_size(Reduction) == 2 ->
+    0;
+
+get_external_reds(Reduction) when tuple_size(Reduction) == 3 ->
+    element(3, Reduction).
+
+
 make_reduce_fun(Lang, ReduceFuns) ->
     FunSrcs = [FunSrc || {_, FunSrc} <- ReduceFuns],
     fun
         (reduce, KVs0) ->
             KVs = detuple_kvs(expand_dups(KVs0, []), []),
             {ok, Result} = couch_query_servers:reduce(Lang, FunSrcs, KVs),
-            {length(KVs), Result};
+            ExternalSize = kv_external_size(KVs, Result),
+            {length(KVs), Result, ExternalSize};
         (rereduce, Reds) ->
-            ExtractFun = fun(Red, {CountsAcc0, URedsAcc0}) ->
+            ExtractFun = fun(Red, {CountsAcc0, URedsAcc0, ExtAcc0}) ->
                 CountsAcc = CountsAcc0 + get_count(Red),
                 URedsAcc = lists:append(URedsAcc0, [get_user_reds(Red)]),
-                {CountsAcc, URedsAcc}
+                ExtAcc = ExtAcc0 + get_external_reds(Red),
+                {CountsAcc, URedsAcc, ExtAcc}
             end,
-            {Counts, UReds} = lists:foldl(ExtractFun, {0, []}, Reds),
+            {Counts, UReds, ExternalSize} = lists:foldl(ExtractFun,
+                {0, [], 0}, Reds),
             {ok, Result} = couch_query_servers:rereduce(Lang, FunSrcs, UReds),
-            {Counts, Result}
+            {Counts, Result, ExternalSize}
     end.
 
 
@@ -1107,3 +1125,9 @@ get_view_queries({Props}) ->
         _ ->
             throw({bad_request, "`queries` member must be a array."})
     end.
+
+
+kv_external_size(KVList, Reduction) ->
+    lists:foldl(fun([[Key, _], Value], Acc) ->
+        size(term_to_binary(Key)) + size(term_to_binary(Value)) + Acc
+    end, size(term_to_binary(Reduction)), KVList).


### PR DESCRIPTION
A new PR in ASF LAND has been issued, Please refer to that one:

https://github.com/apache/couchdb/pull/608

Previously, we were calculating the ExternalSize for views by summing
up all the nodes in the btree. Furthermore, this was the compressed
size. Now we modify the reduce function to return an ExternalSize for
uncompressed values in the KVList.

BugzId:86873

<!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users 
     could notice? -->

## JIRA issue number

<!-- If this is a significant change, please file a JIRA issue at:
     https://issues.apache.org/jira/browse/COUCHDB
     and include the number here and in commit message(s)  -->

## Related Pull Requests

<!-- If your changes affects on multiple components in different 
     repositories please list here links to those pull requests.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
