### PR TITLE
Release candidate 102642

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -92,6 +92,7 @@
 % Used by the compactor
 -export([
     set_update_seq/2,
+    update_header/2,
     copy_security/2
 ]).
 

--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -386,7 +386,7 @@ commit_compaction_data(#st{header = OldHeader} = St0, Fd) ->
     MetaFd = couch_emsort:get_fd(St0#st.id_tree),
     MetaState = couch_emsort:get_state(St0#st.id_tree),
     St1 = bind_id_tree(St0, St0#st.fd, DataState),
-    Header = St1#st.header,
+    Header = couch_bt_engine:update_header(St1, St1#st.header),
     CompHeader = #comp_header{
         db_header = Header,
         meta_state = MetaState

--- a/src/couch/src/couch_os_process.erl
+++ b/src/couch/src/couch_os_process.erl
@@ -167,7 +167,6 @@ init([Command, Options, PortOptions]) ->
     spawn(fun() ->
             % this ensure the real os process is killed when this process dies.
             erlang:monitor(process, Pid),
-            receive _ -> ok end,
             killer(?b2l(KillCmd))
         end),
     OsProc =

--- a/src/couch/test/couch_bt_engine_compactor_tests.erl
+++ b/src/couch/test/couch_bt_engine_compactor_tests.erl
@@ -1,0 +1,130 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_bt_engine_compactor_tests).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+-define(DELAY, 100).
+-define(WAIT_DELAY_COUNT, 50).
+
+
+setup() ->
+    DbName = ?tempdb(),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
+    ok = couch_db:close(Db),
+    create_docs(DbName),
+    DbName.
+
+
+teardown(DbName) when is_binary(DbName) ->
+    couch_server:delete(DbName, [?ADMIN_CTX]),
+    ok.
+
+
+compaction_resume_test_() ->
+    {
+        setup,
+        fun test_util:start_couch/0,
+        fun test_util:stop_couch/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                fun compaction_resume/1
+            ]
+        }
+    }.
+
+
+compaction_resume(DbName) ->
+    ?_test(begin
+        check_db_validity(DbName),
+        compact_db(DbName),
+        check_db_validity(DbName),
+
+        % Force an error when copying document ids
+        with_mecked_emsort(fun() ->
+            compact_db(DbName)
+        end),
+
+        check_db_validity(DbName),
+        compact_db(DbName),
+        check_db_validity(DbName)
+    end).
+
+
+check_db_validity(DbName) ->
+    couch_util:with_db(DbName, fun(Db) ->
+        ?assertEqual({ok, 3}, couch_db:get_doc_count(Db)),
+        ?assertEqual(3, couch_db:count_changes_since(Db, 0))
+    end).
+
+
+with_mecked_emsort(Fun) ->
+    meck:new(couch_emsort, [passthrough]),
+    meck:expect(couch_emsort, iter, fun(_) -> erlang:error(kaboom) end),
+    try
+        Fun()
+    after
+        meck:unload()
+    end.
+
+
+create_docs(DbName) ->
+    couch_util:with_db(DbName, fun(Db) ->
+        Doc1 = couch_doc:from_json_obj({[
+            {<<"_id">>, <<"doc1">>},
+            {<<"value">>, 1}
+
+        ]}),
+        Doc2 = couch_doc:from_json_obj({[
+            {<<"_id">>, <<"doc2">>},
+            {<<"value">>, 2}
+
+        ]}),
+        Doc3 = couch_doc:from_json_obj({[
+            {<<"_id">>, <<"doc3">>},
+            {<<"value">>, 3}
+
+        ]}),
+        {ok, _} = couch_db:update_docs(Db, [Doc1, Doc2, Doc3]),
+        couch_db:ensure_full_commit(Db)
+    end).
+
+
+compact_db(DbName) ->
+    couch_util:with_db(DbName, fun(Db) ->
+        {ok, _} = couch_db:start_compact(Db)
+    end),
+    wait_db_compact_done(DbName, ?WAIT_DELAY_COUNT).
+
+
+wait_db_compact_done(_DbName, 0) ->
+    Failure = [
+        {module, ?MODULE},
+        {line, ?LINE},
+        {reason, "DB compaction failed to finish"}
+    ],
+    erlang:error({assertion_failed, Failure});
+wait_db_compact_done(DbName, N) ->
+    IsDone = couch_util:with_db(DbName, fun(Db) ->
+        not is_pid(couch_db:get_compactor_pid(Db))
+    end),
+    if IsDone -> ok; true ->
+        timer:sleep(?DELAY),
+        wait_db_compact_done(DbName, N - 1)
+    end.

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -341,14 +341,12 @@ find_repl_doc(SrcDb, TgtUUIDPrefix) ->
     SrcUUID = couch_db:get_uuid(SrcDb),
     S = couch_util:encodeBase64Url(crypto:hash(md5, term_to_binary(SrcUUID))),
     DocIdPrefix = <<"_local/shard-sync-", S/binary, "-">>,
-    FoldFun = fun({DocId, {Rev0, {BodyProps}}}, _) ->
+    FoldFun = fun(#doc{id = DocId, body = {BodyProps}} = Doc, _) ->
         TgtUUID = couch_util:get_value(<<"target_uuid">>, BodyProps, <<>>),
         case is_prefix(DocIdPrefix, DocId) of
             true ->
                 case is_prefix(TgtUUIDPrefix, TgtUUID) of
                     true ->
-                        Rev = list_to_binary(integer_to_list(Rev0)),
-                        Doc = #doc{id=DocId, revs={0, [Rev]}, body={BodyProps}},
                         {stop, {TgtUUID, Doc}};
                     false ->
                         {ok, not_found}


### PR DESCRIPTION
This is a patch release for j6843 (audit)

It was prepared using following steps
```
cd src/couchdb
git checkout 18f83628997ca335297ebdb5ba637f8164b75437
git checkout -b release-102642
git push cloudant release-102642
git checkout -b release-candidate-102642
git cherry-pick 99a64b2508e815e5a820c802b0d9c802659e72d3
git cherry-pick 790783e3f8210537aa5c691a90b3608a5c218f72
git cherry-pick 59ebb250b9c6daad09a9861de4fbcebf0b663711
git cherry-pick daab8c16b7362e380c00df74890fae8865e3dbc9
git push cloudant release-candidate-102642
```