### PR TITLE
Allow disabling off-heap messages

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -211,7 +211,7 @@ close_db_if_idle(DbName) ->
 
 
 init([]) ->
-    couch_util:set_mqd_off_heap(),
+    couch_util:set_mqd_off_heap(?MODULE),
 
     % Mark pluggable storage engines as a supported feature
     config:enable_feature('pluggable-storage-engines'),

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -37,7 +37,7 @@
 -export([unique_monotonic_integer/0]).
 -export([check_config_blacklist/1]).
 -export([check_md5/2]).
--export([set_mqd_off_heap/0]).
+-export([set_mqd_off_heap/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -670,12 +670,17 @@ check_md5(Sig, Sig) -> ok;
 check_md5(_, _) -> throw(md5_mismatch).
 
 
-set_mqd_off_heap() ->
-    try
-        erlang:process_flag(message_queue_data, off_heap),
-        ok
-    catch error:badarg ->
-        ok
+set_mqd_off_heap(Module) ->
+    case config:get_boolean("off_heap_mqd", atom_to_list(Module), true) of
+        true ->
+            try
+                erlang:process_flag(message_queue_data, off_heap),
+                ok
+            catch error:badarg ->
+                    ok
+            end;
+        false ->
+            ok
     end.
 
 

--- a/src/couch_log/src/couch_log_server.erl
+++ b/src/couch_log/src/couch_log_server.erl
@@ -58,7 +58,7 @@ log(Entry) ->
 
 
 init(_) ->
-    couch_util:set_mqd_off_heap(),
+    couch_util:set_mqd_off_heap(?MODULE),
     process_flag(trap_exit, true),
     {ok, #st{
         writer = couch_log_writer:init()

--- a/src/ddoc_cache/src/ddoc_cache_lru.erl
+++ b/src/ddoc_cache/src/ddoc_cache_lru.erl
@@ -87,7 +87,7 @@ refresh(DbName, DDocIds) ->
 
 
 init(_) ->
-    couch_util:set_mqd_off_heap(),
+    couch_util:set_mqd_off_heap(?MODULE),
     process_flag(trap_exit, true),
     BaseOpts = [public, named_table],
     CacheOpts = [

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -184,7 +184,7 @@ handle_config_terminate(_Server, _Reason, _State) ->
     erlang:send_after(?RELISTEN_DELAY, whereis(?MODULE), restart_config_listener).
 
 init([]) ->
-    couch_util:set_mqd_off_heap(),
+    couch_util:set_mqd_off_heap(?MODULE),
     ets:new(?SHARDS, [
         bag,
         public,

--- a/src/rexi/src/rexi_server.erl
+++ b/src/rexi/src/rexi_server.erl
@@ -39,7 +39,7 @@ start_link(ServerId) ->
     gen_server:start_link({local, ServerId}, ?MODULE, [], []).
 
 init([]) ->
-    couch_util:set_mqd_off_heap(),
+    couch_util:set_mqd_off_heap(?MODULE),
     {ok, #st{}}.
 
 handle_call(get_errors, _From, #st{errors = Errors} = St) ->


### PR DESCRIPTION
New Cherry Picked:

Allow disabling off-heap messages

Off-heap messages is an Erlang 19 feature:

http://erlang.org/doc/man/erlang.html#process_flag_message_queue_data

It is adviseable to use that setting for processes which expect to receive a
lot of messages. CouchDB sets it for couch_server, couch_log_server and bunch
of others as well.

In some cases the off-heap behavior could alter the timing of message receives
and expose subtle bugs that have been lurking in the code for years. Or could
slightly reduce performance, so a safety measure allow disabling it.

Command History:

```
git cherry-pick ee3c4b5d2e58e35a11e6995d47580554a7d7aca8
[release-candidate-110017 08fb4bf24] Allow disabling off-heap messages
 Author: Nick Vatamaniuc <vatamane@apache.org>
 Date: Thu Sep 6 17:31:34 2018 -0400
 6 files changed, 17 insertions(+), 12 deletions(-)
```
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
