### PR TITLE
Release candidate 112213

### DIFF
--- a/src/couch_log/src/couch_log_sup.erl
+++ b/src/couch_log/src/couch_log_sup.erl
@@ -26,7 +26,7 @@ start_link() ->
 
 init([]) ->
     ok = couch_log_config:init(),
-    {ok, {{one_for_one, 1, 1}, children()}}.
+    {ok, {{one_for_one, 10, 10}, children()}}.
 
 
 children() ->


### PR DESCRIPTION
These commits were cherry-picked for this patch release:

Fixed a couch_log issue that crashed nodes:
```
https://github.com/apache/couchdb/commit/92c7530fc8d5d881cdb452b5412f91b9ead4f1dd
https://github.com/apache/couchdb/commit/c980b8016dcf2c205571c3fb9d25f44e2f631074

git cherry-pick 92c7530fc8d5d881cdb452b5412f91b9ead4f1dd^..c980b8016dcf2c205571c3fb9d25f44e2f631074
[release-candidate-112213 0835bcdae] Do not crash couch_log application when gen_* servers send extra args
 Author: Nick Vatamaniuc <vatamane@apache.org>
 Date: Wed Oct 17 16:24:28 2018 -0400
 2 files changed, 112 insertions(+), 23 deletions(-)
[release-candidate-112213 b2214f428] Improve restart resilience of couch_log application
 Author: Nick Vatamaniuc <vatamane@apache.org>
 Date: Wed Oct 17 17:43:56 2018 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Fixes an ets_lru issue in chttpd:
```
https://github.com/apache/couchdb/commit/2301cf35b8f08659fcdfcebd260d628b067abefd

git cherry-pick 2301cf35b8f08659fcdfcebd260d628b067abefd
[release-candidate-112213 95ed62637] Fix ets_lru configuration in chttpd application
 Author: ILYA Khlopotov <iilyak@apache.org>
 Date: Mon Oct 15 14:19:41 2018 -0700
 1 file changed, 15 insertions(+), 18 deletions(-)

```

