### PR TITLE
Release candidate 122285-2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -104,7 +104,7 @@ DepDescs = [
 {ioq,              "ioq",              {tag, "2.1.2"}},
 {hqueue,           "hqueue",           {tag, "1.0.1"}},
 {smoosh,           "smoosh",           {tag, "1.0.1"}},
-{ken,              "ken",              {tag, "1.0.3"}},
+{ken,              "ken",              {tag, "1.0.6"}},
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},


### PR DESCRIPTION
git cherry-pick 1f224517505125619562f83afcdb587798f583a5
```error: could not apply 1f2245175... update ken to 1.0.6
hint: after resolving the conflicts, mark the corrected paths
hint: with 'git add <paths>' or 'git rm <paths>'
hint: and commit the result with 'git commit'
```
And then resolved conflict and continue.