### PR TITLE
Release candidate 123256

### DIFF
--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -180,6 +180,12 @@ handle_message(complete, Worker, State) ->
     Counters = fabric_dict:update_counter(Worker, 1, State#collector.counters),
     fabric_view:maybe_send_row(State#collector{counters = Counters});
 
+handle_message({execution_stats, _} = Msg, {_,From}, St) ->
+    #collector{callback=Callback, user_acc=AccIn} = St,
+    {Go, Acc} = Callback(Msg, AccIn),
+    rexi:stream_ack(From),
+    {Go, St#collector{user_acc=Acc}};
+
 handle_message(ddoc_updated, _Worker, State) ->
     {stop, State}.
 


### PR DESCRIPTION
git cherry-pick 75b6838ee2dbb050337ad4c19a03ae5ba5d7b63f
[release-candidate-123256 2ccfa7942] Fix missing mango execution stats (part 1)
 Author: Will Holley <willholley@gmail.com>
 Date: Wed Jan 8 11:29:59 2020 +0000
 3 files changed, 23 insertions(+), 6 deletions(-)