### PR TITLE
release candidate 123256-5

### DIFF
--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -170,6 +170,10 @@ handle_hits(CAcc0, [{Sort, Doc} | Rest]) ->
     handle_hits(CAcc1, Rest).
 
 
+handle_hit(CAcc0, Sort, not_found) ->
+    CAcc1 = update_bookmark(CAcc0, Sort),
+    CAcc1;
+
 handle_hit(CAcc0, Sort, Doc) ->
     #cacc{
         limit = Limit,


### PR DESCRIPTION
git cherry-pick 6dd963ac62ddd0a6eacd064ad671d278f75468e9
[release-candidate-123256-5 6fe2ddd1b] Handle not_found docs in mango text indexes
 Author: Will Holley <willholley@gmail.com>
 Date: Fri Jan 17 16:39:23 2020 +0000
 1 file changed, 4 insertions(+)