### PR TITLE
Remove reduntant get_ring_opts call in in dreyfus_fabric_search

### DIFF
--- a/src/dreyfus/src/dreyfus_fabric_search.erl
+++ b/src/dreyfus/src/dreyfus_fabric_search.erl
@@ -56,7 +56,6 @@ go(DbName, DDoc, IndexName, #index_query_args{}=QueryArgs) ->
     Shards = dreyfus_util:get_shards(DbName, QueryArgs),
     LiveNodes = [node() | nodes()],
     LiveShards = [S || #shard{node=Node} = S <- Shards, lists:member(Node, LiveNodes)],
-    RingOpts = dreyfus_util:get_ring_opts(QueryArgs, LiveShards),
     Bookmark1 = dreyfus_bookmark:add_missing_shards(Bookmark0, LiveShards),
     Counters0 = lists:flatmap(fun({#shard{name=Name, node=N} = Shard, After}) ->
         QueryArgs1 = dreyfus_util:export(QueryArgs#index_query_args{


### PR DESCRIPTION
Previously we erroneously got ring opts before and after figuring out live
shards if some shards were not live there was a badmatch failure.

git cherry-pick fb59a6167708d3aba3c22654481742c393f3a9ce into release release-123413
