### PR TITLE
Add detect-secrets integration with GitHub Actions and Makefile

### DIFF
--- a/.github/workflows/detect-secrets.yaml
+++ b/.github/workflows/detect-secrets.yaml
@@ -1,0 +1,42 @@
+name: Detect Secrets Scan
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  detect-secrets:
+    name: Scan for Secrets (uses committed baseline config)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install detect-secrets
+        run: pip install git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets
+
+      - name: Compare baseline
+        run: |
+          cp .secrets.baseline .secrets.baseline.bak
+          detect-secrets scan --update .secrets.baseline --suppress-unscannable-file-warnings
+
+          grep -v '"generated_at":' .secrets.baseline.bak > before.cleaned
+          grep -v '"generated_at":' .secrets.baseline     > after.cleaned
+
+          if ! diff before.cleaned after.cleaned > secrets.diff; then
+            echo "::error::Secrets baseline changed (excluding timestamp)."
+            cat secrets.diff
+            rm .secrets.baseline.bak before.cleaned after.cleaned secrets.diff
+            exit 1
+          else
+            echo "✅ No actual secret changes detected."
+            rm .secrets.baseline.bak before.cleaned after.cleaned secrets.diff
+          fi

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,3796 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2025-08-04T04:16:52Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "dev/pbkdf2.py": [
+      {
+        "hashed_secret": "46ba4a8be2124cbab746bd0a2ef9455dfd09ed9f",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c5db954e419e910fe1eb750471745d904d87034b",
+        "is_verified": false,
+        "line_number": 139,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8ad7cf778d5fdd5479c1fa8652b98f0052abdb5",
+        "is_verified": false,
+        "line_number": 140,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "33102ddbd05f97a4b5c13c0f165634897331e9ae",
+        "is_verified": false,
+        "line_number": 141,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0cc3d78d995466bafa88711ac88b46f36a259a0e",
+        "is_verified": false,
+        "line_number": 147,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4b8463609aecc507de0f1c4a8774b8ed6e9eb42",
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bd662514640b130bb6e9cc26aea84b11f5e3f50c",
+        "is_verified": false,
+        "line_number": 152,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6ed6513a2fa6372e60260eb916355abfa2d9e2d5",
+        "is_verified": false,
+        "line_number": 156,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "92cc2e1ffef5f1db8dc03c0b4f6c2fc0538f836a",
+        "is_verified": false,
+        "line_number": 163,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6527536627bd5d661e413e6ff32dfa7af107b64f",
+        "is_verified": false,
+        "line_number": 166,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cb2ab43239b55fa7e966962ddc3d51475ade1aa8",
+        "is_verified": false,
+        "line_number": 173,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b6734e1aad1945a565e9287e375a26d43515401e",
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c54470ae47a058140c9bb058b44fe50baff43f49",
+        "is_verified": false,
+        "line_number": 187,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b6a20b2a52a2d90bd0cbca3a0962c4fc003f74ba",
+        "is_verified": false,
+        "line_number": 194,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "dev/run": [
+      {
+        "hashed_secret": "7c6cd049c50870eb55c957ccc15248baab38c39c",
+        "is_verified": false,
+        "line_number": 541,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "be5ac8ff51bdcc11f0ab6b005a709c3d6c82ee22",
+        "is_verified": false,
+        "line_number": 786,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "87e16ae988df35824b02549ea668107c3e79c652",
+        "is_verified": false,
+        "line_number": 895,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "nouveau/README.md": [
+      {
+        "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
+        "is_verified": false,
+        "line_number": 61,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "rebar.config.script": [
+      {
+        "hashed_secret": "a041b6b758553ce4a167e4d654263a46443dcdec",
+        "is_verified": false,
+        "line_number": 167,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "rel/overlay/etc/default.ini": [
+      {
+        "hashed_secret": "f8377c90fcfd699f0ddbdcb30c2c9183d2d933ea",
+        "is_verified": false,
+        "line_number": 619,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "rel/overlay/etc/local.ini": [
+      {
+        "hashed_secret": "f8377c90fcfd699f0ddbdcb30c2c9183d2d933ea",
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/b64url/c_src/b64url.c": [
+      {
+        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
+        "is_verified": false,
+        "line_number": 610,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/src/chttpd.erl": [
+      {
+        "hashed_secret": "9a9d02b9964917bc38da3bd2fe629504d5dae1b7",
+        "is_verified": false,
+        "line_number": 392,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0d3ca52f574987ef1440491d0dfa2fd9ec98a15e",
+        "is_verified": false,
+        "line_number": 412,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37958c9c60e58de6c7eb83ffbca719a9d5480e5d",
+        "is_verified": false,
+        "line_number": 613,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ec513e9e1f8fe8ad3b5152ae23a8ab89cfc25098",
+        "is_verified": false,
+        "line_number": 620,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "aed2208021ef42de3287379865c8b82cfe5c24f4",
+        "is_verified": false,
+        "line_number": 622,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e62486355d8c28693ba671e6435fad4ca5a58f11",
+        "is_verified": false,
+        "line_number": 1456,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/src/chttpd_auth.erl": [
+      {
+        "hashed_secret": "ace65eb47a101483aa5eaf0eb638460becb6c844",
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9350177113ab8ce58e445aaa96caa662ec688e94",
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4b6ffa265777c7946ec7018c5d97e08479a572f1",
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/src/chttpd_auth_request.erl": [
+      {
+        "hashed_secret": "4896f3d2180fc0783f7f8987d5f7363cac93cb88",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/src/chttpd_cors.erl": [
+      {
+        "hashed_secret": "b777c243012aa9e0f01258574105be2b0962b326",
+        "is_verified": false,
+        "line_number": 292,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/src/chttpd_httpd_handlers.erl": [
+      {
+        "hashed_secret": "3b13cb60a444623a6ad4ebd40c71b66fd6826a2f",
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/test/eunit/chttpd_auth_tests.erl": [
+      {
+        "hashed_secret": "4ca8bc5fa60c5cb670c03835bbe7a75971852aad",
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c39c1e44e1e0e1e9ad900e67bbb6a4d02a75fd52",
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/test/eunit/chttpd_csp_tests.erl": [
+      {
+        "hashed_secret": "f130c02f55c5c7aabfe51907e4065a7426b52b66",
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/test/eunit/chttpd_dbs_info_test.erl": [
+      {
+        "hashed_secret": "b8346c58de5689be16475c40ca8c5a989b4e0ab4",
+        "is_verified": false,
+        "line_number": 186,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/chttpd/test/eunit/chttpd_local_docs_tests.erl": [
+      {
+        "hashed_secret": "cde514f97a444ee496e59b34b394163265228b2b",
+        "is_verified": false,
+        "line_number": 119,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch/src/couch_att.erl": [
+      {
+        "hashed_secret": "c85d484742dbb7e7ab33c7e4e61c063af84c4369",
+        "is_verified": false,
+        "line_number": 865,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch/src/couch_base32.erl": [
+      {
+        "hashed_secret": "6a40fbb3bd3c0673c9bff6ad305c8181d648a9bb",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch/src/couch_httpd.erl": [
+      {
+        "hashed_secret": "37958c9c60e58de6c7eb83ffbca719a9d5480e5d",
+        "is_verified": false,
+        "line_number": 202,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e62486355d8c28693ba671e6435fad4ca5a58f11",
+        "is_verified": false,
+        "line_number": 1385,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/couch/src/couch_httpd_auth.erl": [
+      {
+        "hashed_secret": "1e853bf8ad2a8bed124c0083054c4a279e4f2794",
+        "is_verified": false,
+        "line_number": 130,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c628e1dc1e68d2abe74f80f97a04868e66f5af11",
+        "is_verified": false,
+        "line_number": 392,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "18dd1cc34c8cdc76f286d95e9122390757c25a57",
+        "is_verified": false,
+        "line_number": 439,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e9665bdcabc846236a5435840e8d4763fbed3591",
+        "is_verified": false,
+        "line_number": 530,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/couch/src/couch_httpd_rewrite.erl": [
+      {
+        "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
+        "is_verified": false,
+        "line_number": 215,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/couch/test/eunit/couch_etag_tests.erl": [
+      {
+        "hashed_secret": "ed3fe28989e5d033a55c67819db01160a789242c",
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch/test/eunit/couch_file_tests.erl": [
+      {
+        "hashed_secret": "fa15abf5771b9f273772d56c68df7f8321bcceb1",
+        "is_verified": false,
+        "line_number": 305,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch/test/eunit/couch_hotp_tests.erl": [
+      {
+        "hashed_secret": "7e0a1242bd8ef9044f27dca45f5f72ad5a1125bf",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch/test/eunit/couch_passwords_tests.erl": [
+      {
+        "hashed_secret": "c5db954e419e910fe1eb750471745d904d87034b",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8ad7cf778d5fdd5479c1fa8652b98f0052abdb5",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "33102ddbd05f97a4b5c13c0f165634897331e9ae",
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0cc3d78d995466bafa88711ac88b46f36a259a0e",
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4b8463609aecc507de0f1c4a8774b8ed6e9eb42",
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bd662514640b130bb6e9cc26aea84b11f5e3f50c",
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch/test/eunit/couch_totp_tests.erl": [
+      {
+        "hashed_secret": "7e0a1242bd8ef9044f27dca45f5f72ad5a1125bf",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "937dcb68f7308eecdb702ef15faa02735fc3cc61",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c71490fc24aa3d19e11282da77032dd9cdb33103",
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch_mrview/test/eunit/couch_mrview_util_tests.erl": [
+      {
+        "hashed_secret": "42a5083d162c81c525d8ab03b6d0e3b0cb78eeab",
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator.erl": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 395,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_auth_session.erl": [
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_verified": false,
+        "line_number": 653,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_doc_processor_worker.erl": [
+      {
+        "hashed_secret": "4e56762920fdbbec94cd018098ee8816ced96455",
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_docs.erl": [
+      {
+        "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
+        "is_verified": false,
+        "line_number": 350,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_httpc.erl": [
+      {
+        "hashed_secret": "a95110a1e49cf9323bc336b7d246851c29792fa5",
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3ecdb1a73d53bafd1d2b47a1e17b6c0d2f650d3a",
+        "is_verified": false,
+        "line_number": 113,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1b386032d2d71993c5d0c6a91fcc10906508e402",
+        "is_verified": false,
+        "line_number": 262,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_verified": false,
+        "line_number": 465,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_httpc_pool.erl": [
+      {
+        "hashed_secret": "e38ad214943daad1d64c102faec29de4afe9da3d",
+        "is_verified": false,
+        "line_number": 207,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2aa60a8ff7fcd473d321e0146afd9e26df395147",
+        "is_verified": false,
+        "line_number": 208,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_ids.erl": [
+      {
+        "hashed_secret": "2c0580ffd7d80319531cf629f5e90f747b1386f1",
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 275,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6c55803d6f1d7a177a0db3eb4b343b0d50f9c111",
+        "is_verified": false,
+        "line_number": 279,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f0578f1e7174b1a41c4ea8c6e17f7a8a3b88c92a",
+        "is_verified": false,
+        "line_number": 291,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "88a5eb98311718d6f074a743087f5629b362e194",
+        "is_verified": false,
+        "line_number": 315,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_parse.erl": [
+      {
+        "hashed_secret": "e40924e653de177fc81e3d976c3cfecbcca3f7ca",
+        "is_verified": false,
+        "line_number": 424,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_verified": false,
+        "line_number": 661,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_scheduler.erl": [
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_verified": false,
+        "line_number": 1511,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_scheduler_job.erl": [
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_verified": false,
+        "line_number": 1208,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_utils.erl": [
+      {
+        "hashed_secret": "97af82f47648cd678add72a98eb9a2eaf4a6aca8",
+        "is_verified": false,
+        "line_number": 230,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c7f088653150b5e9d529a99694fe05fe6cc7bbee",
+        "is_verified": false,
+        "line_number": 232,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4e833168fcc942f33a99c6aebf0130212215c00f",
+        "is_verified": false,
+        "line_number": 237,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61a7508ed1b04e9ada836fcd14d4d8ef5687c7dd",
+        "is_verified": false,
+        "line_number": 244,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "819bba01bb57fec43970ed4ae6b07ae5f5d5a21e",
+        "is_verified": false,
+        "line_number": 261,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_verified": false,
+        "line_number": 588,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b78f576611ec06f96af3ca654c22172a5d746c40",
+        "is_verified": false,
+        "line_number": 664,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/src/couch_replicator_worker.erl": [
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_verified": false,
+        "line_number": 747,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/test/eunit/couch_replicator_connection_tests.erl": [
+      {
+        "hashed_secret": "ba350d2865b62879990973899b56687c844cce91",
+        "is_verified": false,
+        "line_number": 186,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/couch_replicator/test/eunit/couch_replicator_test_helper.erl": [
+      {
+        "hashed_secret": "421bb59c6cb46dbaf2fb9bf1fd02ed84b7614682",
+        "is_verified": false,
+        "line_number": 151,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/basics.rst": [
+      {
+        "hashed_secret": "e39f621cdd46fdde3b5e69e277f35d0470d56b2b",
+        "is_verified": false,
+        "line_number": 341,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/database/bulk-api.rst": [
+      {
+        "hashed_secret": "b489fc296f0ae49f949e44b86927bb610df05c50",
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "638d4b6c749512ae5db2ee522508905302cf6671",
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6b38a402132c22be49ea09281891bf231d222479",
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64779d6adc151107ebcf59437e82e689c598f1c8",
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef4e42f5871ef5799ccc38b2d2757e9121170971",
+        "is_verified": false,
+        "line_number": 88,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "504fc8a6d848d03f0ba5fe13a10354b6829c4e9d",
+        "is_verified": false,
+        "line_number": 637,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "becfb7e5e9af4cc19652d3b2393886b2799d8863",
+        "is_verified": false,
+        "line_number": 638,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "82c366a23087fe904eeb43acc700b3ef1065e5fd",
+        "is_verified": false,
+        "line_number": 639,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eaa0d3bb14fca19c04f32b4d575b1d49400df097",
+        "is_verified": false,
+        "line_number": 658,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "735e233007c4410fde70815a5cc24761e0365fc2",
+        "is_verified": false,
+        "line_number": 676,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bd0a7bc3f9517de8e6c720b67820fcae077f237d",
+        "is_verified": false,
+        "line_number": 677,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "44f74826c883ae2fedf0de80290810df351cd763",
+        "is_verified": false,
+        "line_number": 918,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/database/changes.rst": [
+      {
+        "hashed_secret": "7389fbb4e6230ba2feee7200441c36b7c440580d",
+        "is_verified": false,
+        "line_number": 162,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "883859f814564df56ab11dfe373a56d232f17e3c",
+        "is_verified": false,
+        "line_number": 172,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bee43dec35a7b55964d7dbf02706c2d41d632f8a",
+        "is_verified": false,
+        "line_number": 173,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dd7881479dd8e2dd26035be753420cc669f99178",
+        "is_verified": false,
+        "line_number": 184,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "97599c3769d209dc655a13e2247e19c52bbb3be3",
+        "is_verified": false,
+        "line_number": 266,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f76e9f5a8cb230816032546640e9a8ccf75b5696",
+        "is_verified": false,
+        "line_number": 276,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "54e9f3c6fa8dfeb1bb6dbd2d9f416639164a54d9",
+        "is_verified": false,
+        "line_number": 298,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7f4ed619450332c4acb5248563bc3942bdcea883",
+        "is_verified": false,
+        "line_number": 299,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e9900b5da7d741ed54454eb8704171bfe0c278e9",
+        "is_verified": false,
+        "line_number": 299,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4f1f15201fe0ca8846e0da54c1a74b9cfd80113",
+        "is_verified": false,
+        "line_number": 334,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "117ee7e57570f3379b0a1e2e4a4f3dd4f82842b1",
+        "is_verified": false,
+        "line_number": 345,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "35e0cda0543e4a328eb3ec6fdfe68b342709fc44",
+        "is_verified": false,
+        "line_number": 412,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b24ebb23954e55fba39ff31d3b2018c34831b026",
+        "is_verified": false,
+        "line_number": 412,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5083bddedde8de6475a08cdc7f2a99e78cb85895",
+        "is_verified": false,
+        "line_number": 413,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fbcd5b2ef28340d3cef511da6e51ae966fef21c3",
+        "is_verified": false,
+        "line_number": 415,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1ac9ce67dbcb1ffd3b669a5ad4eb2d44f5a9f58b",
+        "is_verified": false,
+        "line_number": 672,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dfdbef0959b256612f4bef44438d5dcd7227f7ba",
+        "is_verified": false,
+        "line_number": 682,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7047e2e24db15ef241c328b0ace34692e25a89e8",
+        "is_verified": false,
+        "line_number": 748,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "006cf9ffa8b0227ad18efff8c494ad2ce8a1c1d6",
+        "is_verified": false,
+        "line_number": 757,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/database/common.rst": [
+      {
+        "hashed_secret": "34fec2da3bfb6d41e99daadaef48acd6b77841f0",
+        "is_verified": false,
+        "line_number": 362,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/database/find.rst": [
+      {
+        "hashed_secret": "9e789029d0895891b9d207764a9c4bb402bf4a92",
+        "is_verified": false,
+        "line_number": 1455,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/database/misc.rst": [
+      {
+        "hashed_secret": "39fa2e3b59050a19ba62d26dab0498970a28866a",
+        "is_verified": false,
+        "line_number": 380,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8c7fcb0678370a809c1e9c8c0c5ab5896b96fa97",
+        "is_verified": false,
+        "line_number": 459,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/database/security.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/ddoc/common.rst": [
+      {
+        "hashed_secret": "451e410a136449096a285b5dd1d4a65563defc4e",
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/ddoc/views.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 686,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/document/attachments.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 303,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/document/common.rst": [
+      {
+        "hashed_secret": "0670b40a4a0b2d4c03839206140985e3c844084f",
+        "is_verified": false,
+        "line_number": 552,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3dbb3ec81e0341da2c01ab2d02dbebe3d87852c6",
+        "is_verified": false,
+        "line_number": 595,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b635d7598dea3117a46b8ee1c240a3bdc81030dd",
+        "is_verified": false,
+        "line_number": 643,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6a318bfa9006f10af93744ec1df4f67ef2d6cce7",
+        "is_verified": false,
+        "line_number": 651,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9afedb00ce229a4a80cf64b81fc12389d6279894",
+        "is_verified": false,
+        "line_number": 862,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1400cd23f52f719f7ea298e749913f853b97dfd8",
+        "is_verified": false,
+        "line_number": 863,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "882836c3f6ce89cf460c23d0e8b2796c22e1aeb9",
+        "is_verified": false,
+        "line_number": 864,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eb0167e191c11b431992fd4907fe1d30971ce883",
+        "is_verified": false,
+        "line_number": 865,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0a87c754ea7339a5fe388df03568e77b37e02519",
+        "is_verified": false,
+        "line_number": 866,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "685bf1fee823b59bd02550606e8a8a0d6c94e5a4",
+        "is_verified": false,
+        "line_number": 867,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8212a2e09d7abba839dc639d8c018c29d41b61e4",
+        "is_verified": false,
+        "line_number": 868,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "275d9ecb6d994d531738e5c6908c8c970e4b008c",
+        "is_verified": false,
+        "line_number": 869,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/server/authn.rst": [
+      {
+        "hashed_secret": "21927c9c339b4538c024b9623d60000c7ecf34f3",
+        "is_verified": false,
+        "line_number": 64,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "63bb094ca4821a02d77009421b59266dfff2751a",
+        "is_verified": false,
+        "line_number": 170,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/api/server/common.rst": [
+      {
+        "hashed_secret": "ec5fce03c8f235b423f93c6f55e70e0937eba76a",
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b05d72124d7e609b0030e417bd6611c5ce5d131a",
+        "is_verified": false,
+        "line_number": 129,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c7803a9d9d5acbbe30293dcb2810aceb29efd859",
+        "is_verified": false,
+        "line_number": 160,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bbccdf2efb33b52e6c9d0a14dd70b2d415fbea6e",
+        "is_verified": false,
+        "line_number": 510,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5dc74f5f38f9319aeffbab6037583b5cbe2c6085",
+        "is_verified": false,
+        "line_number": 598,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5362f93bdb0ce13cd38c0aebde3879afbcb7fa39",
+        "is_verified": false,
+        "line_number": 601,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 768,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "833f56e1891d0c04ae3aec1ef910f431883f2696",
+        "is_verified": false,
+        "line_number": 810,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "205f511dac206d6aae39bf18e1f07987d2fd5030",
+        "is_verified": false,
+        "line_number": 817,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b9de705384f33efeaeaa5d9ebdd55c03a4c69fce",
+        "is_verified": false,
+        "line_number": 944,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dc3f7ee7513aea5ec243a1c9c9677835c3c5454c",
+        "is_verified": false,
+        "line_number": 1104,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "606de5564a9fcb54c1e672409e991b4b1697042a",
+        "is_verified": false,
+        "line_number": 1295,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4e74d5e05512f1f47364c53909c91e2ef69955f5",
+        "is_verified": false,
+        "line_number": 1510,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a5fcad68f9facdf063fc1d50b45244089882bb6c",
+        "is_verified": false,
+        "line_number": 1519,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a385de4faac0257c74e691cbb540c2123c497df9",
+        "is_verified": false,
+        "line_number": 2333,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7f1e0c042cf4154b3b637d1ae2aca52a8761d784",
+        "is_verified": false,
+        "line_number": 2334,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b27c95a7b4d4a5e6b9ee7406ef4985dd379c3439",
+        "is_verified": false,
+        "line_number": 2335,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6916ad1adca69eb8933536de571aef1df339e194",
+        "is_verified": false,
+        "line_number": 2336,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "68b5decad06c728df38bb3805f3fdead6dc62230",
+        "is_verified": false,
+        "line_number": 2337,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "07b921918f5e3a1adb673cd233bd9f19d67c571f",
+        "is_verified": false,
+        "line_number": 2338,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f3da23409a6cd1b91e82b9f2ea2b08c5f8eff8e0",
+        "is_verified": false,
+        "line_number": 2339,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2dee32aa6eb28495742ad68d8746dcb60e8fc7a5",
+        "is_verified": false,
+        "line_number": 2340,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c0887e3bdad673dbe3b003f19170759ecfd8d1df",
+        "is_verified": false,
+        "line_number": 2341,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9f45c00f83c143776692a8053040c87768b7b9a9",
+        "is_verified": false,
+        "line_number": 2342,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7764f686943645989b4a573e65c51fd124a07e6e",
+        "is_verified": false,
+        "line_number": 2367,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4bce00529bfbcd73c893d5d7de8adf621cb79794",
+        "is_verified": false,
+        "line_number": 2368,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d1783ab2f1414e6addec256b192b95f2531a6a18",
+        "is_verified": false,
+        "line_number": 2369,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "509f50a61e91ef2fa155c9324eb7091127cca732",
+        "is_verified": false,
+        "line_number": 2370,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b5c9402986b92fbd723fc3e7904220aa08e415a7",
+        "is_verified": false,
+        "line_number": 2371,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/best-practices/forms.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/best-practices/iso-date.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/best-practices/reverse-proxies.rst": [
+      {
+        "hashed_secret": "cf4d2385b84329a52ca542285b93d9c4618420df",
+        "is_verified": false,
+        "line_number": 137,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/cluster/purging.rst": [
+      {
+        "hashed_secret": "51a460a080bcb8671cccda4198108a0c87a8b21f",
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8ff1979bb32e8f5a6f720a3af34283d022f77d92",
+        "is_verified": false,
+        "line_number": 82,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/cluster/sharding.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 646,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/config/auth.rst": [
+      {
+        "hashed_secret": "df775c29c319ecd3ae3b6723494d91926d3c3678",
+        "is_verified": false,
+        "line_number": 330,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/config/http.rst": [
+      {
+        "hashed_secret": "f8377c90fcfd699f0ddbdcb30c2c9183d2d933ea",
+        "is_verified": false,
+        "line_number": 447,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8c5baa05113e6148a0a79020708131188fed7212",
+        "is_verified": false,
+        "line_number": 560,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "415980eb797d626d5704ba8d4241002cba656b13",
+        "is_verified": false,
+        "line_number": 565,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/config/intro.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/config/misc.rst": [
+      {
+        "hashed_secret": "e8d21dbff2ade0e56a03edc53bc8b606af4813d4",
+        "is_verified": false,
+        "line_number": 84,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a9a2dff935bffaa720fb9a1cf3efddb4c30847f8",
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a038e20e2fca6db078024b90b62cc75727a3bf91",
+        "is_verified": false,
+        "line_number": 86,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "55006994e90ac47ce57dd8557b7346fb43fc205c",
+        "is_verified": false,
+        "line_number": 87,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "078fcffb0b72a26469257b810cc59f346429b1e3",
+        "is_verified": false,
+        "line_number": 88,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4b1761c13e6ab55e52b5820e34f741a1e9519c13",
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b2f5e4442d2b3a5f5896668d324928118abf2354",
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6649c17dcc1f37b9db4333fa53ff2e7ab6a0c89d",
+        "is_verified": false,
+        "line_number": 91,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a35cfc6c9df28156d6db305b875689996b770423",
+        "is_verified": false,
+        "line_number": 92,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "54c71aed15a7fbaa78402943fda8b18bb1c8a310",
+        "is_verified": false,
+        "line_number": 93,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a596dc01c5f88516dce3044a7b565e31b9736ac4",
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b05e33d403c296fb2d7814d39a7b571bef19611d",
+        "is_verified": false,
+        "line_number": 107,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e1f0c7b7f1101810e4cc7bdf196bcc494d3d3cc9",
+        "is_verified": false,
+        "line_number": 108,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dcb9bf238ca1493f9bbeeb227d92515176f4d637",
+        "is_verified": false,
+        "line_number": 109,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f6c7ada0dc49e242ac39ea7bf6d7255bd260b90e",
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7fb2d400569dc41b54f6ffe699d528f613ed634d",
+        "is_verified": false,
+        "line_number": 111,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bc0e081f6c8be039ffaa515e4e490dda6137a541",
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2a6df8ae593bb49461f459e7ed88964f8a683a52",
+        "is_verified": false,
+        "line_number": 113,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d068e3e549464f795e881a9281381428af190d80",
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a1810dc6055ea100e223d6a27e5bbd78a7969236",
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74f83e05023bb17e8ee78c825386ddc4e2ad8bee",
+        "is_verified": false,
+        "line_number": 126,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "79393f756142415513cc03b7f7ff7c8349c5579e",
+        "is_verified": false,
+        "line_number": 127,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9789f83cfbc49ae41895ff6437679bc7ea2321a3",
+        "is_verified": false,
+        "line_number": 128,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ea0373476fb4d40b203bce04f4311d43d6245584",
+        "is_verified": false,
+        "line_number": 129,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0e94dd0fd90b6eabd8c0bfb895dcf95aeae1afea",
+        "is_verified": false,
+        "line_number": 130,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "34b3e9957e523e41a6cc7ce4771cfc05fcd13c77",
+        "is_verified": false,
+        "line_number": 131,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7294512871dd66bf5f7ade93700f51c92baa8091",
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ab31d35c5f1df5a079b7ee24085cdf61b7b5a961",
+        "is_verified": false,
+        "line_number": 133,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3585f12dd7987bb074485b51bf7743f7b0707a5f",
+        "is_verified": false,
+        "line_number": 134,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "47a51c660cb0ff9795384fff899047b1395073cb",
+        "is_verified": false,
+        "line_number": 135,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/config/replicator.rst": [
+      {
+        "hashed_secret": "f8377c90fcfd699f0ddbdcb30c2c9183d2d933ea",
+        "is_verified": false,
+        "line_number": 302,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/ddocs/ddocs.rst": [
+      {
+        "hashed_secret": "309b6de1cb445090a63314df21fe0130eba330d1",
+        "is_verified": false,
+        "line_number": 412,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "46d7699a619f6ccdc6e64c7a3362619b32e94c8a",
+        "is_verified": false,
+        "line_number": 413,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "278943985cc3a5308a78dbfda71c3a223869ab36",
+        "is_verified": false,
+        "line_number": 414,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e4b5d421b954e3da61a5dd9a57a6315cf480ca33",
+        "is_verified": false,
+        "line_number": 415,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "16812bcd890131e6442a20dd9ef0d269e156e003",
+        "is_verified": false,
+        "line_number": 416,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "43765593d2661040497fc1a23d2fa8cf57c1c456",
+        "is_verified": false,
+        "line_number": 417,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d79ff6b5d1b14960280a1c465645033ac2c31436",
+        "is_verified": false,
+        "line_number": 418,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "24459275facb7b7a9de9919fb506f70f477f8e6a",
+        "is_verified": false,
+        "line_number": 678,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "add7adabb68d295f6c0efecbe80ae716306b42df",
+        "is_verified": false,
+        "line_number": 678,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "861716371d94b98f2f6d65f1b8c00d0d4396a747",
+        "is_verified": false,
+        "line_number": 679,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a09883a60581d4e113daffcf1abd6d65fce6e827",
+        "is_verified": false,
+        "line_number": 679,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0283db127fc6aac41a013f9379de49c2a17d61a4",
+        "is_verified": false,
+        "line_number": 690,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1014c43e444f194f975ea8a4e87f93ab4c37cb18",
+        "is_verified": false,
+        "line_number": 690,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "708724471c4aa5736eca0f4a4fdbc05746a57a93",
+        "is_verified": false,
+        "line_number": 692,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/ddocs/views/collation.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 182,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/ddocs/views/intro.rst": [
+      {
+        "hashed_secret": "36219664778a9893b7fe226f912cd998e222a93e",
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 105,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/ddocs/views/nosql.rst": [
+      {
+        "hashed_secret": "89a633c142fd6ca343ab4e05dbf210d58086f2df",
+        "is_verified": false,
+        "line_number": 136,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6dc5275ba7e249ded4816d1269ab5ba9cdf6b8b0",
+        "is_verified": false,
+        "line_number": 137,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "09b8d82cfed7823d234316cb96914bccd4ae62c9",
+        "is_verified": false,
+        "line_number": 211,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b1f177f93ca567985705840ddf8251d2f54f8476",
+        "is_verified": false,
+        "line_number": 431,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9055381c81b6d6d07fd4d25038757b0382cdf7f8",
+        "is_verified": false,
+        "line_number": 434,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b82d87e8705e172d0464788df54c94c42bc57f4",
+        "is_verified": false,
+        "line_number": 435,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/ddocs/views/pagination.rst": [
+      {
+        "hashed_secret": "6f0f2c1297f1b5007a26c7599336829f12feb57a",
+        "is_verified": false,
+        "line_number": 95,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "13442f34cf32afe401feac7f384034745e9ef3de",
+        "is_verified": false,
+        "line_number": 139,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "62fc4bf6321f289aa2cf8b800e672125a5097907",
+        "is_verified": false,
+        "line_number": 140,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5d9b3ee9dd1929178dcbcfa563c4fd45dfe16e7c",
+        "is_verified": false,
+        "line_number": 141,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b4a71886bf88545c30570d6dff44d0f10a991d5",
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "23b7d0706365558f597083a32f62ad483fcfabb1",
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 159,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6f37cb351a41274b2cbcc3ca907586bfab48dcc3",
+        "is_verified": false,
+        "line_number": 169,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "75475460dbdf0bc2e7c8d8160d37921fa3761184",
+        "is_verified": false,
+        "line_number": 170,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c1223ea5bd4a4e3238c9addc6d83ef2f36c111d7",
+        "is_verified": false,
+        "line_number": 171,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ab0061be60b4fee36bf4ab837e8a0de966fb8994",
+        "is_verified": false,
+        "line_number": 172,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bf2c92d71d8d82189facb8dba596080166ff55d7",
+        "is_verified": false,
+        "line_number": 174,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/install/windows.rst": [
+      {
+        "hashed_secret": "f3bbbd66a63d4bf1747940578ec3d0103530e21d",
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/intro/api.rst": [
+      {
+        "hashed_secret": "6c22ea7cd4ed6601f50785ef01154a1341c33b6b",
+        "is_verified": false,
+        "line_number": 61,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3288e3dcdbd8e97e5b616185550ec9b7c38709b9",
+        "is_verified": false,
+        "line_number": 512,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b7fc16234686258ca54f0b1adc54364e4fb4cd94",
+        "is_verified": false,
+        "line_number": 565,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d654c1e24066c66cb9e6861edad8f3f176f1db35",
+        "is_verified": false,
+        "line_number": 641,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ab57bb06fc891c8ffdf270bb691c3ead23d70baf",
+        "is_verified": false,
+        "line_number": 646,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 711,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/intro/curl.rst": [
+      {
+        "hashed_secret": "6c22ea7cd4ed6601f50785ef01154a1341c33b6b",
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 136,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "31bc6524c50903551ba7ef129c2e963fd03bc1d9",
+        "is_verified": false,
+        "line_number": 137,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/intro/security.rst": [
+      {
+        "hashed_secret": "05a79f06cf3f67f726dae68d18a2290f6c9a50c9",
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 159,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1d15e93197c0bf5a3c6eb6d8c410d0d337de6e3c",
+        "is_verified": false,
+        "line_number": 213,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d0be2dc421be4fcd0172e5afceea3970e2f3d940",
+        "is_verified": false,
+        "line_number": 336,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9fce26a40995fa96d702e8eb34e8bc34afff86ba",
+        "is_verified": false,
+        "line_number": 404,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "41bb4f2d34e46c371c945718aa3c1ca9636609f6",
+        "is_verified": false,
+        "line_number": 409,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 416,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef0ebbb77298e1fbd81f756a4efc35b977c93dae",
+        "is_verified": false,
+        "line_number": 420,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "79cfd39472f32b1bf83136366e1c171f24d9e7b0",
+        "is_verified": false,
+        "line_number": 428,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb749288671a5a14527ac644ec32d256ae1fab8f",
+        "is_verified": false,
+        "line_number": 438,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/intro/tour.rst": [
+      {
+        "hashed_secret": "6c22ea7cd4ed6601f50785ef01154a1341c33b6b",
+        "is_verified": false,
+        "line_number": 46,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 160,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "26912ed0afa278ac1319033d3d550e548bce53bc",
+        "is_verified": false,
+        "line_number": 276,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "44f74826c883ae2fedf0de80290810df351cd763",
+        "is_verified": false,
+        "line_number": 287,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a9347b1f25407dae6f862876cbcfbcf403e6b410",
+        "is_verified": false,
+        "line_number": 298,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/json-structure.rst": [
+      {
+        "hashed_secret": "accb5135f296493e33e88607ab19e6e782b5de34",
+        "is_verified": false,
+        "line_number": 393,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "77dbea4355ef669af8510d3053a445ca22cc358d",
+        "is_verified": false,
+        "line_number": 466,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/maintenance/compaction.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 375,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/partitioned-dbs/index.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 381,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/query-server/protocol.rst": [
+      {
+        "hashed_secret": "e8b19958d0c9b43e7aece476270593a0befc298f",
+        "is_verified": false,
+        "line_number": 165,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae7ec1d07beb6fc63b36688a31f4fe1e4bfa3665",
+        "is_verified": false,
+        "line_number": 202,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "35c61db45721c0d61e649e0c23b4a106cd3b53b2",
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dd25b565570257cfceb90a42641c46b5fac8187d",
+        "is_verified": false,
+        "line_number": 375,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d5e74f1c140415b331ad6241f3058faf0699409",
+        "is_verified": false,
+        "line_number": 683,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1173fd8ebc389828758c4d488f371adfa96dd963",
+        "is_verified": false,
+        "line_number": 720,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "156f3249c5d9d6ae16b98ecad78130e0e85ef446",
+        "is_verified": false,
+        "line_number": 730,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3614298f2f841910a7ef47c6ea2af096bf838c08",
+        "is_verified": false,
+        "line_number": 735,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8811802285c87161be3b2b87af0c0fa1ee842d67",
+        "is_verified": false,
+        "line_number": 758,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/replication/conflicts.rst": [
+      {
+        "hashed_secret": "827ae8df847a631359e488bd0ba4fc6da3453d6f",
+        "is_verified": false,
+        "line_number": 282,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 431,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/replication/protocol.rst": [
+      {
+        "hashed_secret": "4324692552e41ad08c1dd53e980ecf06483aeef7",
+        "is_verified": false,
+        "line_number": 449,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d112cf4fb07e2748f461d0f62ff119cd5e7b26c5",
+        "is_verified": false,
+        "line_number": 592,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99504dac20c27e2872604d75275eda024927052f",
+        "is_verified": false,
+        "line_number": 605,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "398e43b3aae4f49c0e6fe8ce0d107a88a2c466bf",
+        "is_verified": false,
+        "line_number": 611,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a5bad93ec978ce6cee985aa0fa0d791c3c040f0e",
+        "is_verified": false,
+        "line_number": 1020,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f49a30d3757a7e72d2554b4e10c235261d114011",
+        "is_verified": false,
+        "line_number": 1187,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "12c485f2a5069a6c6148e8a62d7f5c21f07d75d7",
+        "is_verified": false,
+        "line_number": 1213,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "275d9ecb6d994d531738e5c6908c8c970e4b008c",
+        "is_verified": false,
+        "line_number": 1329,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74b838328a1012f011d93602e4345ccc577b64af",
+        "is_verified": false,
+        "line_number": 1346,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "224f84d53ce970cd403c06d610d216622ac9d3f3",
+        "is_verified": false,
+        "line_number": 1359,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3eb6f81ac49a75e2c01600bb89fb930cb8185a41",
+        "is_verified": false,
+        "line_number": 1437,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f7c63d0e6d5c2821d23a4d5d5a9b7e22fb9becd8",
+        "is_verified": false,
+        "line_number": 1458,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "044fcf07b68030dbccdb550b5a3cdc4663f46a35",
+        "is_verified": false,
+        "line_number": 1459,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4dea5e9d1019346975c9a3cb128f080565a79d05",
+        "is_verified": false,
+        "line_number": 1460,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e796cf0de777c79798ebce5bf998a45ff19566a3",
+        "is_verified": false,
+        "line_number": 1461,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "140b8750052fb3c0b3b37054609d8d93e837788e",
+        "is_verified": false,
+        "line_number": 1462,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee315bc6ed7f56de6ca0a7f4582768cf4798bec0",
+        "is_verified": false,
+        "line_number": 1463,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4705a1cd543d24b7a7b8d24ad4fb76599d5be2bd",
+        "is_verified": false,
+        "line_number": 1464,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1394bf3f21c7ee311d44f91f36dff3e801bb1a03",
+        "is_verified": false,
+        "line_number": 1656,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "abbf892324755a940af540e20d347a67a3d3ace2",
+        "is_verified": false,
+        "line_number": 1676,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/replication/replicator.rst": [
+      {
+        "hashed_secret": "dc3f7ee7513aea5ec243a1c9c9677835c3c5454c",
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 700,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 773,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "949bbd3bf220ef8a77cd533ca09812200b217641",
+        "is_verified": false,
+        "line_number": 803,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/setup/cluster.rst": [
+      {
+        "hashed_secret": "3bc6d26d9d8dab842149d07757cafabe587447f7",
+        "is_verified": false,
+        "line_number": 209,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "92372ca83747546f69a0ecf5498922d094773e66",
+        "is_verified": false,
+        "line_number": 209,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 342,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/setup/single-node.rst": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/docs/src/whatsnew/2.0.rst": [
+      {
+        "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
+        "is_verified": false,
+        "line_number": 113,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/dreyfus/test/eunit/dreyfus_purge_test.erl": [
+      {
+        "hashed_secret": "937dcb68f7308eecdb702ef15faa02735fc3cc61",
+        "is_verified": false,
+        "line_number": 873,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "03beb859ab17c706f08f8743221b73b0000efc66",
+        "is_verified": false,
+        "line_number": 898,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/exxhash/c_src/xxhash.h": [
+      {
+        "hashed_secret": "59b5ae7d61242c21f6266c44d596d410619882c5",
+        "is_verified": false,
+        "line_number": 4711,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7d85c7075f74c9dad077a188b16aebb5b37d9b6c",
+        "is_verified": false,
+        "line_number": 4987,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e5e8a0d690c60767100493e927be02c2eaeadb7e",
+        "is_verified": false,
+        "line_number": 5513,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfe12c3dd5ecd14ad3f4ce85deb0ca2ee11b0c1",
+        "is_verified": false,
+        "line_number": 5602,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "05261d1f43c2145f971d49365112fda2f9d44712",
+        "is_verified": false,
+        "line_number": 6250,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/exxhash/test/exxhash_tests.erl": [
+      {
+        "hashed_secret": "35344b34a27cd11f6080687b52fb77373eaea24b",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "40703f08d76f265a87c8b3fd8ed7e9fe30a5cd4c",
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d56c174df12cdf96757216c90d3749573cb79b06",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa4442c1f6b006314993d64561c2788b5f8b98c0",
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/fabric/src/fabric_view_changes.erl": [
+      {
+        "hashed_secret": "a347547301ed2e6a8d55f7a909e8701e47438023",
+        "is_verified": false,
+        "line_number": 840,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de2ff2a15c03ce865701fe370c1f935b289d8ca2",
+        "is_verified": false,
+        "line_number": 849,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9c8b3c0244980dd63fb3a27c1df3c35929992bbc",
+        "is_verified": false,
+        "line_number": 854,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "60b4edf65aff235396f0a7afc93ff39aafa76d0b",
+        "is_verified": false,
+        "line_number": 855,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5c5e761a427be89313a8e48847469d0cdf75d835",
+        "is_verified": false,
+        "line_number": 900,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ccbf3b35996d8bdd4685863a11576749adcab7ed",
+        "is_verified": false,
+        "line_number": 906,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "33a7573236cb2993c4cea07367d79854b6a7c086",
+        "is_verified": false,
+        "line_number": 907,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/fabric/test/eunit/fabric_tests.erl": [
+      {
+        "hashed_secret": "9bbc9e32b2096d620893e4248e77ae1c60f37b04",
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "285a7a3a0cbf7295511d41eb668e27dcd16f6088",
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8f5ee72fcf61c9284802dd6d1a3f5b1b3301eb58",
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/jwtf/test/jwtf_tests.erl": [
+      {
+        "hashed_secret": "4e4377832cfedcf928cff185aabaa3a9243e288a",
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a4dc3108878fb48c99376a641a40bc5ce531c8d1",
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b739dd16db23b9ab566f9025b75907cb3183e7ce",
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "18bd1ec7f37b42a40dcf0b9b176450f3887e1280",
+        "is_verified": false,
+        "line_number": 226,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4b16843ae5e4c88583e231b41f91e5379d19e57d",
+        "is_verified": false,
+        "line_number": 270,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d66f1ec2b699b80688a288f78b46c0b86db73b32",
+        "is_verified": false,
+        "line_number": 271,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a28ce75f6fa5be7d7277ed3ff6d88b778d1c51a2",
+        "is_verified": false,
+        "line_number": 272,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "264ed25af6a17bb30bbb005cdfe64ad38b0c1114",
+        "is_verified": false,
+        "line_number": 293,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d2f48a6e562db03c86a9750cf74488c205ae04b4",
+        "is_verified": false,
+        "line_number": 294,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "aebe9e7646212d6afd4597520d845a227914d34e",
+        "is_verified": false,
+        "line_number": 358,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a83d1323ff8eee4feb42eeb560421416591e8226",
+        "is_verified": false,
+        "line_number": 359,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1e740260fad43e9ef8296faf18d256073c3ae4a6",
+        "is_verified": false,
+        "line_number": 360,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e01e5d42f83d71da4aadd953875ef53ef8ce56d4",
+        "is_verified": false,
+        "line_number": 361,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b12d17ebb9a39668a7fcf9322734ac4f88206680",
+        "is_verified": false,
+        "line_number": 362,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e37728b0d3ad795a85f262125db2e5ee707c1109",
+        "is_verified": false,
+        "line_number": 363,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b3d19dbe75f9a6b193dbed565008041883c8083e",
+        "is_verified": false,
+        "line_number": 367,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f6d7490bdad23d044cb4b64bee1dca061d345d38",
+        "is_verified": false,
+        "line_number": 368,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61ed9b1860ec46c502bdcb339e03e8c64bec57d2",
+        "is_verified": false,
+        "line_number": 369,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "434391a0de7fd5a9e9f1581a13ea3321f6eeca0b",
+        "is_verified": false,
+        "line_number": 370,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef4d7eb107215b3504f7d176ccf3bb1892c20fd4",
+        "is_verified": false,
+        "line_number": 371,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "698871c6d5c508e56e4fbd557d529f6b4dadcef2",
+        "is_verified": false,
+        "line_number": 372,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "95c3e418f0968e4ad10f56b0d4b3af23fce5909d",
+        "is_verified": false,
+        "line_number": 388,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 393,
+        "type": "Private Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e840a8214946618bcd458ea43088002d9aea57da",
+        "is_verified": false,
+        "line_number": 394,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c970ebe6f803858b264ac8e5b3af0714e62cafed",
+        "is_verified": false,
+        "line_number": 395,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/mango/test/11-ignore-design-docs-test.py": [
+      {
+        "hashed_secret": "5cd3602616c3a07b4740876d310d486b363d7479",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0a2cb7e1fc4d77f2d8b6d813ec0ef0282638ae9a",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/mango/test/12-use-correct-index-test.py": [
+      {
+        "hashed_secret": "5cd3602616c3a07b4740876d310d486b363d7479",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0a2cb7e1fc4d77f2d8b6d813ec0ef0282638ae9a",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3a03a837e2795e6d445ebab6d79215018f184c67",
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "16a365c439381190a2187a549b133b24d116c3f8",
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/mango/test/13-stable-update-test.py": [
+      {
+        "hashed_secret": "5cd3602616c3a07b4740876d310d486b363d7479",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0a2cb7e1fc4d77f2d8b6d813ec0ef0282638ae9a",
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/mango/test/23-explain-indexes-test.py": [
+      {
+        "hashed_secret": "a4cad83a71cb8b9573b2c230b229fa7b6136d355",
+        "is_verified": false,
+        "line_number": 406,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/mango/test/friend_docs.py": [
+      {
+        "hashed_secret": "14a12825324cde556e705ec7214e5c914f0139c8",
+        "is_verified": false,
+        "line_number": 59,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f5b76a149bcec14accd66ce1080d8602f5518486",
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d1639bf6cf2b59fc1e23de6403107e9acf832355",
+        "is_verified": false,
+        "line_number": 91,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "79be27f451b7f40fa102ca3c6257d90836526d47",
+        "is_verified": false,
+        "line_number": 105,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "df73547d222de20ac6ef9fcad3a085bcaccb781e",
+        "is_verified": false,
+        "line_number": 119,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d8a460a1f49407488d4bcb0590f7d464f8ab275e",
+        "is_verified": false,
+        "line_number": 129,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "39f805959ca932848e7c7c1d588091fb83d966a6",
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6879442008a9572c6c748122ba21db9a6cd19c58",
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "073180e9e971981c305b26c37924097a78b706e2",
+        "is_verified": false,
+        "line_number": 171,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "890d04d74caa22fbdf1483de759949f616001ea1",
+        "is_verified": false,
+        "line_number": 193,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8597c8c57544fa242569c7874550a2692418af6c",
+        "is_verified": false,
+        "line_number": 207,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3488b597858b0a455cf3c46e6a13074dca819164",
+        "is_verified": false,
+        "line_number": 225,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "43e51b25050f847b1da622dbf8a6c250f9f648dc",
+        "is_verified": false,
+        "line_number": 240,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a5bc2f3fe85ea5452fa2a1f0aac4aa552d72fab2",
+        "is_verified": false,
+        "line_number": 250,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0c1088578ab0913c40e1e5418a87e04bab3640ca",
+        "is_verified": false,
+        "line_number": 261,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6eaddbda7dbc04705e2c49cbe08829354f2b6ab2",
+        "is_verified": false,
+        "line_number": 271,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/mango/test/limit_docs.py": [
+      {
+        "hashed_secret": "5cd3602616c3a07b4740876d310d486b363d7479",
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0a2cb7e1fc4d77f2d8b6d813ec0ef0282638ae9a",
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ac63bd7a7facde2220f383ab787f523359c751f0",
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "773266ccea10d130213ea472131311ba03b8db78",
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57c360bb1ec9b124342d19b9cc8be27a45069c2d",
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a44959b4a8cdd7223c0cd1ba9cdb4e019a3319de",
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ac3c1dfeb4c7b440e6055007936514ffedba6563",
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5823cde0ba84b7662591130fdb10dd1db71a0696",
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f388b52ce75f1a9b62088c58b658548121d25c69",
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae83c5fd1c98820212cc2870ee8976b416a5da1c",
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4e937c19086e33585d824a02b1d8847d05bd611c",
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ca205d5f610ed9d641bd0d97f07375a087b5d3c",
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f564f35be19ca3fd1312170193b2f3f5b699c8d0",
+        "is_verified": false,
+        "line_number": 42,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f28bf0a70ad66fe0f96d62a1bff8df5fcf63daba",
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bfc3737a95ed2e5ed9ba48d555730e9e38c6aab1",
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1600d9669c9eca3e11d25dc946af6b5d9fad1cb8",
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "436b2a9c7bd2e5f679008a2a0c6e62be9cf190a2",
+        "is_verified": false,
+        "line_number": 46,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8ad324047498e9dca4008e5fbd482557c5d83a79",
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72a8b5fb4e8ebe98413421ecde9722143025ac0b",
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "826b1b4b3a20acd64594cc91d1f06e4b69990782",
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "60575c513235da22a26124490834a367e056c0fb",
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "10db0e4b1a75da3fe8eaedfc71a240e948b279ca",
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "28a03a0ef79e55f4debbe5d4cb220e1b4d9cc027",
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c270a6c331463e6cf6840fccac8aca8f06e2e3fe",
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57ba36feec8a6e3deff31c0165a623404863b27b",
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6cf5fa74cee43d1ca8f09cdac5c3a263f161ec40",
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d56eafded626090b757fcad4df82f6d73b72a879",
+        "is_verified": false,
+        "line_number": 56,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61b7bdf1a3b3e112189ea2c8575edbf0bb8f7f7f",
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48817f6020e828b72e900769cef476f46ff95d7d",
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8d47c28652cce3f9f22277f88cf9ea3e95a37dd2",
+        "is_verified": false,
+        "line_number": 59,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fd6b7f9bab35342a6e16218f2f0dc95cfc19a54c",
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "01c597395bf2876337fd23c6392c737c3449ff41",
+        "is_verified": false,
+        "line_number": 61,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eed07aca06ecc084e318fd749b3b1a22ffacbaac",
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "96f14cc7fd70105a9ec83a42e192f7e0eed07b40",
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c524f4b02427b323d77d85fc07fc6854ce7ceb57",
+        "is_verified": false,
+        "line_number": 64,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4e186cf84ad2f351b134e4873fcefcadde5b421c",
+        "is_verified": false,
+        "line_number": 65,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f0e4fdfd023be643bd34db0c78ce0fad611a4120",
+        "is_verified": false,
+        "line_number": 66,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d985babf888930334d74f2bffdde89b92b0539ed",
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "458bfc53a5120a5e4ed498d91b6c2e2dc30870ed",
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ab1816457ec974b79a47146bf52ceb988384b016",
+        "is_verified": false,
+        "line_number": 69,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb545a4c39bffdfa8c75ff3be8aff903c7dfac71",
+        "is_verified": false,
+        "line_number": 70,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e50c27b98462b7d51c970ecf05b06b318b096c8d",
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d15b179dd9b1c09ca7e84065411da726eb96a432",
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "27a1dbff6feaed971ee80090615070510478556f",
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "24d19b9e8bd74d342d20729ae546097f045846d3",
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e1fcd5bdd27553654bb3493c9a435d46f6dcfe78",
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b6aad2ae733214cf4c8d0bf418ff9a4a3e5e57fd",
+        "is_verified": false,
+        "line_number": 76,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "30cce7d34cd90d407b4479fc7434940e8c367421",
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eb29836e0e7386c43cefd313ed7602f8b7a748dd",
+        "is_verified": false,
+        "line_number": 78,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "01101da3b36e36763dce8197aac5246ec2dcf605",
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a906117ab37d2b5337ce3818aa50106b415fff6c",
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3a18dc29e20350e6807333a6704476774b356667",
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fd147222c3b65db34eff89bb6d569e9ac8bc8996",
+        "is_verified": false,
+        "line_number": 82,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f3200c05d38f041b7eea4d71993662fe868248d9",
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7e3fe6f34357223bfae8672fa8416dd2eb20c44f",
+        "is_verified": false,
+        "line_number": 84,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ebc53f1e9fa1e9bfad142079253312ab40faf04d",
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "749c5772578e7292bb2578492cf96711609e303e",
+        "is_verified": false,
+        "line_number": 86,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c7bc1ff35a84d0a3609292713a64c623789f4feb",
+        "is_verified": false,
+        "line_number": 87,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37e87e51f38681267824b287ef85810f27d2c9e7",
+        "is_verified": false,
+        "line_number": 88,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff6832821aa482a1ffcbd052501cee4744ee2151",
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "df4162ed62ba52958481d5fd3a33deefc38b2327",
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5b51e7a297fdd15b8e710f42b33791da129c2926",
+        "is_verified": false,
+        "line_number": 91,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "75761bcc1a1f6f3a6f87b79f52b6d7804c11e1bd",
+        "is_verified": false,
+        "line_number": 92,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "802dba2d12c3eb5a1c25ba8fe2bc68b18eb73474",
+        "is_verified": false,
+        "line_number": 93,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4d5677e1488d5dd58b7d3e437ec2b29efa4a3fe",
+        "is_verified": false,
+        "line_number": 94,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7d2d78cd94c61a3b1eac486b4940565e4934f048",
+        "is_verified": false,
+        "line_number": 95,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2dac19a30d313bb94ec3780ecc312163be8779d0",
+        "is_verified": false,
+        "line_number": 96,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0bcf618236ef8faad5f0d63baca0ab5fa6774f3f",
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b353dc9bc9616767189c1894c669ade011105e8f",
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eb6f1884adbddbe85e8d207f0ae6ba8fea9e3323",
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e63a301047a3cdffec2061841411539ed0529ce8",
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b885857c296f8cee954df0e4e52ab14aee6bf186",
+        "is_verified": false,
+        "line_number": 101,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b50405e8edf288b01eb62d533a8f2696fec637f",
+        "is_verified": false,
+        "line_number": 102,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fd3ac0841fb1daee38d88f3bb2648b12e153857e",
+        "is_verified": false,
+        "line_number": 103,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d11b4958c4ca874c8902113e83d735f8dcc40c48",
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "src/mango/test/user_docs.py": [
+      {
+        "hashed_secret": "c084ea2fb1a33c0f41c0f13c01ff71094d4b586b",
+        "is_verified": false,
+        "line_number": 370,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d2d6f822d81cbe7c5f0161baa86dbd5d8be3d699",
+        "is_verified": false,
+        "line_number": 379,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "44952717f0f909ddfe4377938b002fd019132eb9",
+        "is_verified": false,
+        "line_number": 388,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/setup/README.md": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 111,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "src/setup/src/setup.erl": [
+      {
+        "hashed_secret": "1020ac0f3bd19484ab7f135fa2e3b2295543a056",
+        "is_verified": false,
+        "line_number": 260,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/setup/test/t-frontend-setup.sh": [
+      {
+        "hashed_secret": "ccd470cb83682073924a1e26a5c55186bb025e29",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d42c7b91557894a04caa3af926288485902671a6",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bfe0188a4634644e25c046ced2468b45210cd4fd",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/setup/test/t-single-node.sh": [
+      {
+        "hashed_secret": "b7bb62034b410cc9324491f9a402a8c6c20fc0a2",
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "317056b40d89c124f0a2faa1f24a9fb0897ea82d",
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/setup/test/t.sh": [
+      {
+        "hashed_secret": "ccd470cb83682073924a1e26a5c55186bb025e29",
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bfe0188a4634644e25c046ced2468b45210cd4fd",
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/lib/couch/dbtest.ex": [
+      {
+        "hashed_secret": "38375f4bb945703d7d55589fb4716f8ec7311ca8",
+        "is_verified": false,
+        "line_number": 128,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/lib/step/user.ex": [
+      {
+        "hashed_secret": "be3957fd6b35dec75539f54acb7864820fa0b67d",
+        "is_verified": false,
+        "line_number": 70,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b67cd3370671349b81938a6617a8ae3768be1e7",
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/attachment_paths_test.exs": [
+      {
+        "hashed_secret": "a0ee2fcf50b7c0329f2674bd435b62f6a75d6bbe",
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/attachments_test.exs": [
+      {
+        "hashed_secret": "32a16cd21234058f3055effb2a704f2748e20919",
+        "is_verified": false,
+        "line_number": 272,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/jwtauth_test.exs": [
+      {
+        "hashed_secret": "7a431a8d34e7416872c2d682bdb0987be1b76ce2",
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7668fbc628172cee6d3efa99366ba6d6cbd310a7",
+        "is_verified": false,
+        "line_number": 78,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c8f5e9937cea5da990d5247ed3a23b671d750b4c",
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/partition_crud_test.exs": [
+      {
+        "hashed_secret": "5d25d41c8a4c46a99cb4e695b98870ee1e84fd61",
+        "is_verified": false,
+        "line_number": 281,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/reader_acl_test.exs": [
+      {
+        "hashed_secret": "03d67c263c27a453ef65b29e30334727333ccbcd",
+        "is_verified": false,
+        "line_number": 194,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/replication_test.exs": [
+      {
+        "hashed_secret": "4b9ca9345fd540e7fda6a214234f1c2ee8ec6097",
+        "is_verified": false,
+        "line_number": 254,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/show_documents_test.exs": [
+      {
+        "hashed_secret": "309b6de1cb445090a63314df21fe0130eba330d1",
+        "is_verified": false,
+        "line_number": 140,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "46d7699a619f6ccdc6e64c7a3362619b32e94c8a",
+        "is_verified": false,
+        "line_number": 141,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "278943985cc3a5308a78dbfda71c3a223869ab36",
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e4b5d421b954e3da61a5dd9a57a6315cf480ca33",
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "16812bcd890131e6442a20dd9ef0d269e156e003",
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "43765593d2661040497fc1a23d2fa8cf57c1c456",
+        "is_verified": false,
+        "line_number": 145,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d79ff6b5d1b14960280a1c465645033ac2c31436",
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/elixir/test/users_db_security_test.exs": [
+      {
+        "hashed_secret": "1bc0264d5bf8869899640171b693092d8c4899f8",
+        "is_verified": false,
+        "line_number": 283,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8843d7f92416211de9ebb963ff4ce28125932878",
+        "is_verified": false,
+        "line_number": 341,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1e2c4a3907913f7ab94ef873834fe7505c74706d",
+        "is_verified": false,
+        "line_number": 482,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -569,3 +569,34 @@ ifeq ($(with_nouveau), 1)
 		--locald-config test/config/test-config.ini \
 		--no-eval 'mix test --trace --include test/elixir/test/config/nouveau.elixir'
 endif
+
+.PHONY: update-secrets
+
+update-secrets:
+	@echo "🚀 Starting detect-secrets workflow..."
+
+	# 🧼 Clean any existing virtual environment
+	@echo "🧹 Cleaning old virtual environment (if any)..."
+	@rm -rf .venv-ds
+
+	# 🛠️  Set up a new virtual environment
+	@echo "🐍 Creating fresh virtual environment at .venv-ds..."
+	@python3 -m venv .venv-ds
+
+	# 📦 Upgrade pip silently
+	@echo "📦 Upgrading pip..."
+	@.venv-ds/bin/pip install --upgrade pip > /dev/null
+
+	# 🔍 Install latest detect-secrets
+	@echo "🔐 Installing detect-secrets..."
+	@.venv-ds/bin/pip install git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets > /dev/null
+
+	# 📊 Scan and update the baseline
+	@echo "🔎 Scanning for secrets and updating .secrets.baseline..."
+	@.venv-ds/bin/detect-secrets scan --update .secrets.baseline --suppress-unscannable-file-warnings
+
+	# 🧽 Cleanup the virtual environment
+	@echo "🧼 Removing virtual environment..."
+	@rm -rf .venv-ds
+
+	@echo "✅ Done! .secrets.baseline is updated."

--- a/README.rst
+++ b/README.rst
@@ -127,3 +127,27 @@ source code.
 The following provides more details on the included cryptographic software:
 
 CouchDB includes a HTTP client (ibrowse) with SSL functionality.
+
+🔐 Detect Secrets Enforcement
+------------------------------
+
+This repository uses [`detect-secrets`](https://github.com/IBM/detect-secrets-stream) to prevent committing sensitive information like API keys, tokens, and passwords.
+
+**🚀 How It Works**
+
+Secrets are tracked using a `.secrets.baseline` file. This file contains a hash of detected secret patterns and is version-controlled.
+
+On every pull request, GitHub Actions will:
+- Scan the codebase using the committed baseline.
+- Fail the build if new untracked secrets are found.
+
+**🛠 Update the Baseline**
+
+If your PR is failing due to newly detected secrets (false positives or intentional additions), follow the steps below to update the baseline:
+
+**✅ One-Command Update**
+
+Use the provided `Makefile` to automatically install and run `detect-secrets`, then clean up:
+
+```bash
+make update-secrets


### PR DESCRIPTION

## Overview

Issue: https://github.ibm.com/cloudant/releng/issues/1062

Added GitHub Action to scan secrets on PRs
Included Makefile for easy baseline updates
Auto-installs detect-secrets and cleans up
Added short README for developer usage
Configured baseline with exclusions and plugin tweaks


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
